### PR TITLE
Add babybuddy to listed images

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -21,6 +21,7 @@
 * [linuxserver/airsonic](images/docker-airsonic.md)
 * [linuxserver/apprise-api](images/docker-apprise-api.md)
 * [linuxserver/audacity](images/docker-audacity.md)
+* [linuxserver/babybuddy](images/docker-babybuddy.md)
 * [linuxserver/bazarr](images/docker-bazarr.md)
 * [linuxserver/beets](images/docker-beets.md)
 * [linuxserver/boinc](images/docker-boinc.md)


### PR DESCRIPTION
Babyuddy [exists](https://github.com/linuxserver/docker-documentation/blob/master/images/docker-babybuddy.md), but it's not listed in the images list.