### PR TITLE
Update docker-compose.md

### DIFF
--- a/general/docker-compose.md
+++ b/general/docker-compose.md
@@ -4,6 +4,8 @@
 
 Compose is a tool for defining and running multi-container Docker applications. With Compose, you use a YAML file to configure your application’s services. Then, with a single command, you create and start all the services from your configuration. 
 
+Note that when inputting data for variables, you must follow standard YAML rules. In the case of passwords with special characters this can mean escaping them properly or properly quoting the variable. The best course of action if you do not know how to do this or are unwilling to research, is to stick to alphanumeric characters only. 
+
 ## Installation
 
 ### Install Option 1 (recommended):

--- a/general/docker-compose.md
+++ b/general/docker-compose.md
@@ -4,7 +4,7 @@
 
 Compose is a tool for defining and running multi-container Docker applications. With Compose, you use a YAML file to configure your application’s services. Then, with a single command, you create and start all the services from your configuration. 
 
-Note that when inputting data for variables, you must follow standard YAML rules. In the case of passwords with special characters this can mean escaping them properly or properly quoting the variable. The best course of action if you do not know how to do this or are unwilling to research, is to stick to alphanumeric characters only. 
+Note that when inputting data for variables, you must follow standard YAML rules. In the case of passwords with special characters this can mean escaping them properly ($ is the escape character) or properly quoting the variable. The best course of action if you do not know how to do this or are unwilling to research, is to stick to alphanumeric characters only. 
 
 ## Installation
 


### PR DESCRIPTION
People have been complaining about the lack of information about properly escaping strings in compose. This adds a note to the docker compose section of docs and encourages use of pure alphanumeric strings for those who are unwilling or incapable of research.