### PR TITLE
Fix exclusion regex

### DIFF
--- a/images/.pages
+++ b/images/.pages
@@ -1,2 +1,2 @@
 nav:
-    - ... | regex=^docker-((?!(baseimage-|base-alpine-example|base-ubuntu-example|ci|doc-builder|gazee|gmail-order-bot|hydra2|jenkins-builder|letsencrypt|musicbrainz|mylar|pydio|readme-sync|rutorrent|sickrage|tester)).)*.md$
+    - ... | regex=^docker-(?!(baseimage-.*|base-alpine-example|base-ubuntu-example|ci|doc-builder|gazee|gmail-order-bot|hydra|hydra2|jenkins-builder|letsencrypt|musicbrainz|mylar|pydio|readme-sync|rutorrent|sickrage|tester)\.).*\.md$


### PR DESCRIPTION
`ci` was preventing `audacity` from being included.

Old logic:
`docker-` followed by any characters, but look for pattern X to exclude, so `docker-someXthing` would be excluded.

New logic:
`docker-` followed immediately by pattern X and then a `.` should be excluded, anything else should be included