### PR TITLE
Awesome lsio.md rename

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -17,7 +17,7 @@
 * [Volumes](general/volumes.md)
 * [Fleet](general/fleet.md)
 * [SWAG setup](general/swag.md)
-* [Awesome LSIO](general/awesome-lsio.md)
+* [Container list and descriptions](general/container-descriptions.md)
 
 ## Images
 

--- a/general/.pages
+++ b/general/.pages
@@ -9,4 +9,4 @@ nav:
     - volumes.md
     - fleet.md
     - swag.md
-    - awesome-lsio.md
+    - container-descriptions.md

--- a/general/container-descriptions.md
+++ b/general/container-descriptions.md
@@ -1,4 +1,4 @@
-# Awesome LSIO
+# Container list and descriptions
 
 ## Administration
 


### PR DESCRIPTION
I suggest changing the "Awesome LSIO" link on the docs.linuxserver.io page to something that conveys more meaning. I have proposed "Container list and descriptions".

Rationale:  I have been using LSIO for a few years but did not know this page existed due to the obscure title. Until now, I have been getting information on individual containers through the Fleet page. 

Thanks :) 