### PR TITLE
Add concurrency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,10 @@ name: Build mkdocs and deploy to GitHub Pages
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:


### PR DESCRIPTION
Prevent force pushes to gh-pages branch when multiple jobs are triggered. 

As the source material doesn't get overwritten a new run will pick up the change that triggered the would-be-cancelled run. 

https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-to-cancel-any-in-progress-job-or-run