### PR TITLE
ci: :green_heart: use sparse checkout and cache properly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,16 +12,31 @@ jobs:
     name: Build docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
-      - uses: actions/setup-python@v5.0.0
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
+          sparse-checkout: |
+            docs
+      - name: Setup python
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.x
-      - uses: actions/cache@v3.3.2
+      - name: Get pip cache directory
+        id: pip-cache
+        run: |
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v4.0.0
         with:
-          key: ${{ github.ref }}
-          path: .cache
-      - run: pip install -r docs/requirements.txt
-      - run: mkdocs build
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
+      - name: Build documentation
+        run: mkdocs build
 
   deploy:
     if: github.event_name == 'push' && contains(fromJson('["refs/heads/master", "refs/heads/main"]'), github.ref)
@@ -29,15 +44,28 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
         with:
-          fetch-depth: '0'
-      - uses: actions/setup-python@v5.0.0
+          fetch-depth: 0
+          sparse-checkout: |
+            docs
+      - name: Setup python
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.x
-      - uses: actions/cache@v3.3.2
+      - name: Get pip cache directory
+        id: pip-cache
+        run: |
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v4.0.0
         with:
-          key: ${{ github.ref }}
-          path: .cache
-      - run: pip install -r docs/requirements.txt
-      - run: mkdocs gh-deploy --force
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
Checking the build logs, the cache step in the deploy action should now be working correctly. The sparse checkout changes are meant to speed up builds slightly, but won't have much effect here since almost the entire repo is used in the mkdocs output.