### PR TITLE
Fix hostip entry in docker-znc.md

### DIFF
--- a/docs/images/docker-znc.md
+++ b/docs/images/docker-znc.md
@@ -36,7 +36,7 @@ The architectures supported by this image are:
 
 ## Application Setup
 
-To log in to the application, browse to http://<hostip>:6501.
+To log in to the application, browse to `http://<hostip>:6501`.
 
 * Default User: admin
 * Default Password: admin


### PR DESCRIPTION
The ticks are missing, resulting in the `<hostip>` not showing in the .md