### PR TITLE
Update swag.md

### DIFF
--- a/docs/general/swag.md
+++ b/docs/general/swag.md
@@ -234,6 +234,8 @@ services:
     container_name: swag
     cap_add:
       - NET_ADMIN
+    networks:
+      - lsio
     environment:
       - PUID=1000
       - PGID=1000


### PR DESCRIPTION
in this section, we show how to assign an externally created network in docker run, but leave it out completely in the compose snip.

see https://discord.com/channels/354974912613449730/1267835599830777930 for source of change