### PR TITLE
add new eol items to reasonable endeavors

### DIFF
--- a/docs/misc/support-policy.md
+++ b/docs/misc/support-policy.md
@@ -34,6 +34,8 @@ There are many alternative configurations that should broadly work for most of o
 * Docker installed from distro repos (use the [official repos](https://docs.docker.com/engine/install/) instead)
 * Docker installed via Snap (use the [official repos](https://docs.docker.com/engine/install/) instead)
 * EOL versions of Docker (where there is no option to upgrade)
+* EOL versions of the Linux Kernel (where there is no option to upgrade)
+* EOL versions of your host linux distribution (where there is no option to upgrade)
 * Podman (Rootless or Rootful)
 * Routing container traffic through a VPN
 * Use of macvlan/ipvlan networks


### PR DESCRIPTION
add EOL kernels (such as those used by synology) and EOL linux distributions that cannot be upgraded to the reasonable endeavors list. I believe reasonable endeavors only implies best effort.