### PR TITLE
Update all discord links to use the linuxserver.io redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The team resides primarily in our Discord server. We also have a forum if chat i
 
 | Where | Link |
 | :--- | :--- |
-| Discord | [https://discord.gg/YWrKVTn](https://discord.gg/YWrKVTn) |
+| Discord | [https://linuxserver.io/discord](https://linuxserver.io/discord) |
 | Forum | [https://discourse.linuxserver.io](https://discourse.linuxserver.io) |
 
 For those interested in our CI environment via Jenkins: [https://ci.linuxserver.io/](https://ci.linuxserver.io/)

--- a/docs/general/docker-compose.md
+++ b/docs/general/docker-compose.md
@@ -122,7 +122,7 @@ Defining the containers running on your server as code is a core tenet of a "Dev
 
 ## Support Requests
 
-If you would like to request support, you can do so on [our discord server](https://discord.gg/linuxserver) or [our forum](https://discourse.linuxserver.io/). When you do so, please provide all the necessary information like the server and platform info, docker container log and the compose yaml.
+If you would like to request support, you can do so on [our discord server](https://linuxserver.io/discord) or [our forum](https://discourse.linuxserver.io/). When you do so, please provide all the necessary information like the server and platform info, docker container log and the compose yaml.
 
 If your compose yaml makes use of .env files, please post an output of `docker compose config` or `docker compose config -f /path/to/compose.yml` for the entire yaml, or `docker compose config <service name>` for a single service, as it will automatically replace the environment variables with their actual values.
 

--- a/docs/general/swag.md
+++ b/docs/general/swag.md
@@ -1,6 +1,6 @@
 # SWAG
 
-The goal of this guide is to give you ideas on what can be accomplished with the [LinuxServer SWAG docker image](https://hub.docker.com/r/linuxserver/swag) and to get you started. We will explain some of the basic concepts and limitations, and then we'll provide you with common examples. If you have further questions, you can ask on [our forum](https://discourse.linuxserver.io/) or join our Discord for conversations: <https://discord.gg/YWrKVTn>
+The goal of this guide is to give you ideas on what can be accomplished with the [LinuxServer SWAG docker image](https://hub.docker.com/r/linuxserver/swag) and to get you started. We will explain some of the basic concepts and limitations, and then we'll provide you with common examples. If you have further questions, you can ask on [our forum](https://discourse.linuxserver.io/) or join our [Discord](https://linuxserver.io/discord) for conversations.
 
 ## Introduction
 
@@ -1222,37 +1222,35 @@ This error means that nginx can't talk to the application. There is a few common
 
     - Delete it, and restart the container to have it regenerate
     - Manually set the content(we wont override it)
- 
+
 Here are a few troubleshooting steps:
 
 - Try to ping the container from the swag container:
     `docker exec swag ping <container name>` (If your swag container isn't named `swag`, replace `swag` with the swag container's name).
     - If this doesn't work:
         - Check if the container is actually running
-        - check if both swag and the container in question are on the same container network.
-        - try to find the ip of the container on the network shared with swag (e.g. `docker inspect <container name>`) and try to ping that from swag (`docker exec swag ping <container ip>`)
-          - If this succeeds, you have an issue with name resolution inside docker networks
-          - If this fails, you either have an issue with docker networking in general or the containers don't share a common network.
+        - Check if both swag and the container in question are on the same container network.
+        - Try to find the ip of the container on the network shared with swag (e.g. `docker inspect <container name>`) and try to ping that from swag (`docker exec swag ping <container ip>`)
+            - If this succeeds, you have an issue with name resolution inside docker networks
+            - If this fails, you either have an issue with docker networking in general or the containers don't share a common network.
     - If this works:
         - Try to fetch the web interface from the swag container:
-          `docker exec swag curl http(s)://<container name>:<application port>` (make sure that this matches whatever is in your proxy conf)
-          - If this works: Check your proxy conf again. Probably something (protocol, container name, port) is wrong there
-          - If this doesn't work:
-            - Check the startup log of the application (`docker logs <container name>`).
-                - Did it start sucessfully/Did it fail for some reason?
-                - Many applications print what endpoint they are running on there. Check if this matches the values in your proxy conf and the ones used for curl
-                - Check if the interface the application listens on is correct. Usually this should be 0.0.0.0, but the ip the container has on the network shared with swag should also be fine.
-                  If only 127.0.0.1 or another unrelated IP is listened there, this could be the issue
-            - Check what protocol and port the application actually listens at.
-              Are your sure you've used the right values?
+            `docker exec swag curl http(s)://<container name>:<application port>` (make sure that this matches whatever is in your proxy conf)
+            - If this works: Check your proxy conf again. Probably something (protocol, container name, port) is wrong there
+            - If this doesn't work:
+                - Check the startup log of the application (`docker logs <container name>`).
+                    - Did it start sucessfully/Did it fail for some reason?
+                    - Many applications print what endpoint they are running on there. Check if this matches the values in your proxy conf and the ones used for curl
+                    - Check if the interface the application listens on is correct. Usually this should be 0.0.0.0, but the IP the container has on the network shared with swag should also be fine. If only 127.0.0.1 or another unrelated IP is listed there, this could be the issue.
+                - Check what protocol and port the application actually listens at. Are your sure you've used the right values?
 
 ## Final Thoughts
 
-This image can be used in many different scenarios as it is a full fledged web server with some bells and whistles added. The above examples should be enough to get you started. For more information, please refer to the official documentation on either [Github](https://github.com/linuxserver/docker-swag/blob/master/README.md) or [Docker Hub](https://hub.docker.com/r/linuxserver/swag). If you have questions or issues, or want to discuss and share ideas, feel free to visit our discord: <https://discord.gg/YWrKVTn>
+This image can be used in many different scenarios as it is a full fledged web server with some bells and whistles added. The above examples should be enough to get you started. For more information, please refer to the official documentation on either [Github](https://github.com/linuxserver/docker-swag/blob/master/README.md) or [Docker Hub](https://hub.docker.com/r/linuxserver/swag). If you have questions or issues, or want to discuss and share ideas, feel free to visit our [Discord server](https://linuxserver.io/discord).
 
 ### How to Request Support
 
-As you can see in this article, there are many different configurations, therefore we need to understand your exact setup before we can provide support. If you encounter a bug and confirm that it's a bug, please report it on [our github thread](https://github.com/linuxserver/docker-swag). If you need help with setting it up, [join our discord](https://discord.gg/YWrKVTn) and upload the following info to a service like pastebin and post the link:
+As you can see in this article, there are many different configurations, therefore we need to understand your exact setup before we can provide support. If you encounter a bug and confirm that it's a bug, please report it on [our github thread](https://github.com/linuxserver/docker-swag). If you need help with setting it up, [join our discord](https://linuxserver.io/discord) and upload the following info to a service like pastebin and post the link:
 
 - Docker run/create or compose yml you used
 - Full docker log (`docker logs swag`)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ extra:
     - icon: fontawesome/solid/otter
       link: https://linuxserver.io
     - icon: fontawesome/brands/discord
-      link: https://discord.gg/YWrKVTn
+      link: https://linuxserver.io/discord
     - icon: fontawesome/brands/discourse
       link: https://discourse.linuxserver.io
     - icon: fontawesome/brands/github


### PR DESCRIPTION
Missed these as part of the previous PR, this makes it consistent across the board.