### PR TITLE
LSIO_FIRST_PARTY in container branding docs

### DIFF
--- a/docs/general/container-branding.md
+++ b/docs/general/container-branding.md
@@ -16,6 +16,8 @@ On start-up, the base image will automatically load the branding into its init, 
 
 Hopefully this makes it simpler for everyone to manage the branding of your images when using our bases.
 
-Note: if you're branding a non-base image, you must set the ENV variable `LSIO_FIRST_PARTY=false` to avoid LSIO from overwriting it.
+!!! note
+
+    If you're branding a non-base image, you must set the ENV variable `LSIO_FIRST_PARTY=false` to avoid LSIO from overwriting it.
 
 A final note: if you've previously overridden the `init-adduser` run file to do custom branding, we recommend switching to the above approach so that you don't miss out on any future changes to that init step.

--- a/docs/general/container-branding.md
+++ b/docs/general/container-branding.md
@@ -16,4 +16,6 @@ On start-up, the base image will automatically load the branding into its init, 
 
 Hopefully this makes it simpler for everyone to manage the branding of your images when using our bases.
 
+Note: if you're branding a non-base image, you must set the ENV variable `LSIO_FIRST_PARTY=false` to avoid LSIO from overwriting it.
+
 A final note: if you've previously overridden the `init-adduser` run file to do custom branding, we recommend switching to the above approach so that you don't miss out on any future changes to that init step.


### PR DESCRIPTION
Branding doesn't work for non-base images unless you set LSIO_FIRST_PARTY=false