### PR TITLE
added namespace reference to traefik label

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -238,7 +238,7 @@ hide:
         Then on our `foo` service we tell it to use this rule, as well as telling Traefik the backend is running on https.
 
         ```yml
-            - traefik.http.services.foo.loadbalancer.serverstransport=ignorecert
+            - traefik.http.services.foo.loadbalancer.serverstransport=ignorecert@file
             - traefik.http.services.foo.loadbalancer.server.scheme=https
         ```
 


### PR DESCRIPTION
the reference to the created serversTransports needs a namespace reference (@file), because it is not created in the same namespace as the label. Without @file you will get en error, that traefik can not find the transport.