### PR TITLE
docs(faq): Add caddy reverse proxy guide

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -248,20 +248,23 @@ hide:
 
         To skip this verification we can modify site entry of the [caddyfile](https://caddyserver.com/docs/quick-starts/caddyfile) as shown below:
 
-        *Note: replace `calibre.xxx.com` with your domain and `172.xxx.xxx.xxx:8181` with your backend service IP and port.*
+    !!! note
+        Replace `calibre.xxx.com` with your domain and `172.xxx.xxx.xxx:8181` with your backend service IP and port.
 
-        ```caddyfile
-        calibre.xxx.com {
-            reverse_proxy https://172.xxx.xxx.xxx:8181 {
-                transport http {
-                    tls
-                    tls_insecure_skip_verify
-                }
+
+    ```caddyfile
+    calibre.xxx.com {
+        reverse_proxy https://172.xxx.xxx.xxx:8181 {
+            transport http {
+                tls
+                tls_insecure_skip_verify
             }
         }
-        ```
+    }
+    ```
 
-        **Bonus Tip 1**: If you find yourself needing to do this for multiple services, you can also define a [caddy snippet](https://caddyserver.com/docs/caddyfile/concepts#snippets) and reuse it in your caddyfile like so:
+    ???+ tip "Bonus Tip 1: Caddy Snippets"
+        If you find yourself needing to do this for multiple services, you can also define a [caddy snippet](https://caddyserver.com/docs/caddyfile/concepts#snippets) and reuse it in your caddyfile like so:
 
         ```caddyfile
         (allow_insecure_ssl) {
@@ -277,7 +280,8 @@ hide:
         }
         ```
 
-        **Bonus Tip 2**: If you use [caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-proxy), you can simply apply the following labels to your docker-compose yaml file:
+    ???+ tip "Bonus Tip 2: caddy-docker-proxy"
+        If you use [caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-proxy), you can simply apply the following labels to your docker-compose yaml file:
 
         ```yaml
         labels:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -241,7 +241,53 @@ hide:
             - traefik.http.services.foo.loadbalancer.serverstransport=ignorecert@file
             - traefik.http.services.foo.loadbalancer.server.scheme=https
         ```
+  
+    === "Caddy"
 
+        When reverse proxying an HTTPS backend that uses a self-signed certificate, Caddy will normally reject it because it cannot verify the certificate authority. 
+
+        To skip this verification we can modify site entry of the [caddyfile](https://caddyserver.com/docs/quick-starts/caddyfile) as shown below:
+
+        *Note: replace `calibre.xxx.com` with your domain and `172.xxx.xxx.xxx:8181` with your backend service IP and port.*
+
+        ```caddyfile
+        calibre.xxx.com {
+            reverse_proxy https://172.xxx.xxx.xxx:8181 {
+                transport http {
+                    tls
+                    tls_insecure_skip_verify
+                }
+            }
+        }
+        ```
+
+        **Bonus Tip 1**: If you find yourself needing to do this for multiple services, you can also define a [caddy snippet](https://caddyserver.com/docs/caddyfile/concepts#snippets) and reuse it in your caddyfile like so:
+
+        ```caddyfile
+        (allow_insecure_ssl) {
+            transport http {
+                tls
+                tls_insecure_skip_verify
+            }
+        }
+        calibre.xxx.com {
+            reverse_proxy https://172.xxx.xxx.xxx:8181 {
+                import allow_insecure_ssl
+            }
+        }
+        ```
+
+        **Bonus Tip 2**: If you use [caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-proxy), you can simply apply the following labels to your docker-compose yaml file:
+
+        ```yaml
+        labels:
+            caddy: calibre.xxx.com
+            caddy.reverse_proxy: "{{upstreams https 8181}}"
+            caddy.reverse_proxy.transport: http
+            caddy.reverse_proxy.transport.tls:
+            caddy.reverse_proxy.transport.tls_insecure_skip_verify:
+        ```
+        
 ??? faq "Why does LinuxServer.io recommend to use docker-compose over Portainer?"
 
     ##### Why does LinuxServer.io recommend to use docker-compose over Portainer? { #portainer }


### PR DESCRIPTION
I had some struggle getting [caddy](https://caddyserver.com/) reverse proxying to work with docker with the [calibre](https://docs.linuxserver.io/images/docker-calibre/) image. So I ended adding what worked for me as a guide.

Massive thanks to `xhp` from caddy community whose helpful [post](https://caddy.community/t/the-equivalent-tls-insecure-skip-verify-in-reverse-proxy/7456/3) guided me to the solution.

A visual preview of the added docs:
<img width="1920" height="1538" alt="CleanShot 2025-10-09 at 11 36 00@2x" src="https://github.com/user-attachments/assets/4c828146-0f3e-42b8-a1b9-5938368942b1" />
